### PR TITLE
Sparse matrix checking

### DIFF
--- a/R/fdsm.R
+++ b/R/fdsm.R
@@ -37,14 +37,17 @@ fdsm <- function(B,
   #Argument Checks
   if ((sparse!="TRUE") & (sparse!="FALSE")) {stop("sparse must be either TRUE or FALSE")}
   if ((trials < 1) | (trials%%1!=0)) {stop("trials must be a positive integer")}
-  if (class(B)!="matrix") {stop("input bipartite data must be a matrix")}
+  if (class(B) != "matrix" & !(is(B, "sparseMatrix"))) {stop("input bipartite data must be a matrix")}
 
   #Project to one-mode data
   if (sparse=="TRUE") {
-    B <- Matrix::Matrix(B,sparse=T)
-    P<-B%*%Matrix::t(B)
+    if (!is(B, "sparseMatrix")) {
+      B <- Matrix::Matrix(B, sparse = T)
     }
-  if (sparse=="FALSE") {P<-B%*%t(B)}
+    P<-B%*%Matrix::t(B)
+  } else {
+    P<-B%*%t(B)
+  }
 
   #Create Positive and Negative Matrices to hold backbone
   Positive <- matrix(0, nrow(P), ncol(P))

--- a/R/fdsm.R
+++ b/R/fdsm.R
@@ -44,9 +44,9 @@ fdsm <- function(B,
     if (!is(B, "sparseMatrix")) {
       B <- Matrix::Matrix(B, sparse = T)
     }
-    P<-B%*%Matrix::t(B)
+    P <- Matrix::tcrossprod(B)
   } else {
-    P<-B%*%t(B)
+    P <- tcrossprod(B)
   }
 
   #Create Positive and Negative Matrices to hold backbone
@@ -96,11 +96,13 @@ fdsm <- function(B,
     for (row in 1:R){rm[row,hp[[row]]]=1}
     Bstar <- rm
 
-    if (sparse=="TRUE") {Bstar <- Matrix::Matrix(Bstar,sparse=T)}
-
     #Construct Pstar from Bstar
-    if (sparse=="TRUE") {Pstar<-Bstar%*%Matrix::t(Bstar)}
-    if (sparse=="FALSE") {Pstar<-Bstar%*%t(Bstar)}
+    if (sparse=="TRUE") {
+      Bstar <- Matrix::Matrix(Bstar,sparse=T)
+      Pstar<-Matrix::tcrossprod(Bstar)
+    } else {
+      Pstar <- tcrossprod(Bstar)
+    }
 
     #Start estimation timer; print message
     if (i == 1) {

--- a/R/hyperg.R
+++ b/R/hyperg.R
@@ -23,7 +23,7 @@ hyperg <- function(B){
   if (class(B)!="matrix") {stop("input bipartite data must be a matrix")}
   message("Finding the Backbone using Hypergeometric Distribution")
 
-  P <-B%*%t(B)
+  P <- tcrossprod(B)
   df <- data.frame(as.vector(P))
   names(df)[names(df)=="as.vector.P."] <- "projvalue"
 

--- a/R/sdsm.R
+++ b/R/sdsm.R
@@ -53,10 +53,10 @@ sdsm <- function(B,
       if (!is(B, "sparseMatrix")) {
         B <- Matrix::Matrix(B, sparse = T)
       }
-      P <- B %*% t(B)
+      P <- Matrix::tcrossprod(B)
     }
   } else {
-    P <- B %*% t(B)
+    P <- tcrossprod(B)
   }
 
   #Create Positive and Negative Matrices to hold backbone
@@ -108,8 +108,11 @@ sdsm <- function(B,
 
 
     #Construct Pstar from Bstar
-    if (sparse=="TRUE") {Pstar<-Bstar%*%Matrix::t(Bstar)}
-    if (sparse=="FALSE") {Pstar<-Bstar%*%t(Bstar)}
+    if (sparse=="TRUE") {
+      Pstar <- Matrix::tcrossprod(Bstar)
+    } else {
+      Pstar <- tcrossprod(Bstar)
+    }
 
     #Check whether Pstar edge is larger/smaller than P edge
     Positive <- Positive + (Pstar > P)+0

--- a/R/sdsm.R
+++ b/R/sdsm.R
@@ -49,10 +49,15 @@ sdsm <- function(B,
 
   #Project to one-mode data
   if (sparse=="TRUE") {
-    B <- Matrix::Matrix(B,sparse=T)
-    P<-B%*%Matrix::t(B)
+    if (sparse == "TRUE") {
+      if (!is(B, "sparseMatrix")) {
+        B <- Matrix::Matrix(B, sparse = T)
+      }
+      P <- B %*% t(B)
+    }
+  } else {
+    P <- B %*% t(B)
   }
-  if (sparse=="FALSE") {P<-B%*%t(B)}
 
   #Create Positive and Negative Matrices to hold backbone
   Positive <- matrix(0, nrow(P), ncol(P))

--- a/R/sdsm.R
+++ b/R/sdsm.R
@@ -44,7 +44,7 @@ sdsm <- function(B,
   if ((sparse!="TRUE") & (sparse!="FALSE")) {stop("sparse must be either TRUE or FALSE")}
   if ((model!="logit") & (model!="probit") & (model!="log") & (model!="cloglog")) {stop("model must be: logit | probit | log | cloglog")}
   if ((trials < 1) | (trials%%1!=0)) {stop("trials must be a positive integer")}
-  if (class(B)!="matrix") {stop("input bipartite data must be a matrix")}
+  if (class(B) != "matrix" & !(is(B, "sparseMatrix"))) {stop("input bipartite data must be a matrix")}
 
 
   #Project to one-mode data

--- a/R/universal.R
+++ b/R/universal.R
@@ -25,7 +25,7 @@ universal <- function(M,
   if ((class(lower)!="function") & (class(lower)!="numeric") & (class(lower)!="NULL")) {stop("lower must be either function or numeric")}
 
   if (bipartite == TRUE){
-    P <- M%*%t(M)
+    P <- tcrossprod(M)
   } else {
     P <- M
   }


### PR DESCRIPTION
This set of updates does two main things.  First, it allows a few of the backbone functions to accept sparse matrices or regular matrices as arguments.  If the argument is already a sparse matrix, the functions no longer attempt to convert the matrix into a sparse matrix.

Second, it converts a few instances of `B %*% t(B)` into `tcrossprod(B)`.  According to the `tcrossprod` documentation, `tcrossprod` is equivalent, but slightly faster.

Please feel free to take or leave these changes.  If there's any fixes I need to make, or if you need clarification on anything, please let me know.

Thanks for creating this package!