### PR TITLE
bicm speedup

### DIFF
--- a/R/bicm.R
+++ b/R/bicm.R
@@ -260,13 +260,18 @@ bicm <- function(graph,
   sy[nonfixed_cols] <- sr_y[r_invert_cols_deg]
 
   #### plug everything into probability matrix ####
-  r_probs <- matrix(0, length(sx[nonfixed_rows]), length(sy[nonfixed_cols]))
-  for (i in 1:length(sx[nonfixed_rows])){
-    for (j in 1:length(sy[nonfixed_cols])){
-      xy <- sx[nonfixed_rows][i]*sy[nonfixed_cols][j]
-      r_probs[i,j] <- xy/(1+xy)
-    }#end j
-  }#end i
+  f <- function(x,y){
+    z <- x*y
+    z/(1+z)
+  }
+  r_probs <- outer(sx[nonfixed_rows],sy[nonfixed_cols],f)
+  # r_probs <- matrix(0, length(sx[nonfixed_rows]), length(sy[nonfixed_cols]))
+  # for (i in 1:length(sx[nonfixed_rows])){
+  #   for (j in 1:length(sy[nonfixed_cols])){
+  #     xy <- sx[nonfixed_rows][i]*sy[nonfixed_cols][j]
+  #     r_probs[i,j] <- xy/(1+xy)
+  #   }#end j
+  # }#end i
 
   probs[nonfixed_rows,nonfixed_cols] <- r_probs
   return(probs)

--- a/R/sdsm.R
+++ b/R/sdsm.R
@@ -74,6 +74,7 @@ sdsm <- function(B,
   for (i in 1:rows){
     ### Compute prob.mat[i,]*prob.mat[j,] for each j ###
     prob.imat <- sweep(prob.mat, MARGIN = 2, prob.mat[i,], `*`)
+    # prob.imat <- prob.mat*matrix(prob.mat[i,],nrow = nrow(prob.mat),ncol=ncol(prob.mat),byrow = TRUE)
 
     ### Find cdf, below or equal to value for negative, above or equal to value for positive ###
     ### Using RNA approximation ###


### PR DESCRIPTION
This is a speedup for the computation of `r_probs` in `bicm.R`.
Instead of the double for loop, the outer function is used with a custom function `f`.
For larger graphs, this seems to have a significant impact.

I also tested 
`prob.imat <- prob.mat*matrix(prob.mat[i,],nrow = nrow(prob.mat),ncol=ncol(prob.mat),byrow = TRUE)` 
instead of
`prob.imat <- sweep(prob.mat, MARGIN = 2, prob.mat[i,], `*`)`

which sometimes gave a speedup and sometimes not. So I left it commented out for now.